### PR TITLE
Add job role creation functionality

### DIFF
--- a/src/models/job-role.ts
+++ b/src/models/job-role.ts
@@ -18,6 +18,7 @@ export enum JobStatus {
 }
 
 export interface JobRole {
+  id: number;
   name: string;
   location: string;
   capability: Capability;

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -1,5 +1,23 @@
-import type { JobRole } from "../models/job-role.js";
+import type {
+  Band,
+  Capability,
+  JobRole,
+  JobStatus,
+} from "../models/job-role.js";
+
+export interface JobRoleCreateData {
+  name: string;
+  location: string;
+  capability: Capability;
+  band: Band;
+  closingDate: Date;
+  numberOfOpenPositions: number;
+  status: JobStatus;
+  description: string;
+  responsibilities: string[];
+}
 
 export interface JobRoleservice {
   getAllJobs(): JobRole[];
+  addJob(jobData: JobRoleCreateData): JobRole;
 }

--- a/src/services/jobRoleMemoryService.ts
+++ b/src/services/jobRoleMemoryService.ts
@@ -1,13 +1,35 @@
 import type { JobRole } from "../models/job-role.js";
-import type { JobRoleservice } from "./interfaces.js";
+import type { JobRoleCreateData, JobRoleservice } from "./interfaces.js";
 
 export class JobRoleMemoryService implements JobRoleservice {
   private jobRoles: JobRole[] = [];
+  private nextId: number = 1;
 
   constructor(initialJobRoles: JobRole[]) {
     this.jobRoles = [...initialJobRoles];
+    // Set nextId to be one higher than the highest existing ID
+    this.nextId = Math.max(...this.jobRoles.map((job) => job.id), 0) + 1;
   }
+
   getAllJobs(): JobRole[] {
     return this.jobRoles;
+  }
+
+  addJob(jobData: JobRoleCreateData): JobRole {
+    const newJob: JobRole = {
+      id: this.nextId++,
+      name: jobData.name,
+      location: jobData.location,
+      capability: jobData.capability,
+      band: jobData.band,
+      closingDate: jobData.closingDate,
+      numberOfOpenPositions: jobData.numberOfOpenPositions,
+      status: jobData.status,
+      description: jobData.description,
+      responsibilities: [...jobData.responsibilities],
+    };
+
+    this.jobRoles.push(newJob);
+    return newJob;
   }
 }

--- a/src/services/jobRoleProvider.ts
+++ b/src/services/jobRoleProvider.ts
@@ -8,6 +8,7 @@ import {
 export function ProvideJobRoles(): JobRole[] {
   return [
     {
+      id: 1,
       name: "Software Engineer",
       location: "Bangalore",
       capability: Capability.Data,
@@ -26,6 +27,7 @@ export function ProvideJobRoles(): JobRole[] {
       ],
     },
     {
+      id: 2,
       name: "Data Scientist",
       location: "Hyderabad",
       capability: Capability.Workday,
@@ -44,6 +46,7 @@ export function ProvideJobRoles(): JobRole[] {
       ],
     },
     {
+      id: 3,
       name: "Product Manager",
       location: "Pune",
       capability: Capability.Engineering,

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import { Band, Capability, JobStatus } from "../models/job-role.js";
+import { sanitizeJobRoleData, validateJobRoleData } from "./validation.js";
+
+describe("Validation Utils", () => {
+  describe("validateJobRoleData", () => {
+    const validJobData = {
+      name: "Software Engineer",
+      location: "London",
+      capability: Capability.Engineering,
+      band: Band.E3,
+      closingDate: new Date("2025-12-31"),
+      numberOfOpenPositions: 2,
+      status: JobStatus.Open,
+      description: "A software engineering role",
+      responsibilities: ["Code", "Review", "Test"],
+    };
+
+    it("should validate correct job role data", () => {
+      const result = validateJobRoleData(validJobData);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    describe("name validation", () => {
+      it("should require name", () => {
+        const data = { ...validJobData, name: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "name",
+          message: "Name is required and must be a non-empty string",
+        });
+      });
+
+      it("should reject empty name", () => {
+        const data = { ...validJobData, name: "" };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "name",
+          message: "Name is required and must be a non-empty string",
+        });
+      });
+
+      it("should reject non-string name", () => {
+        const data = { ...validJobData, name: 123 };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "name",
+          message: "Name is required and must be a non-empty string",
+        });
+      });
+    });
+
+    describe("location validation", () => {
+      it("should require location", () => {
+        const data = { ...validJobData, location: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "location",
+          message: "Location is required and must be a non-empty string",
+        });
+      });
+
+      it("should reject empty location", () => {
+        const data = { ...validJobData, location: "   " };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "location",
+          message: "Location is required and must be a non-empty string",
+        });
+      });
+    });
+
+    describe("capability validation", () => {
+      it("should require capability", () => {
+        const data = { ...validJobData, capability: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "capability",
+          message: "Capability is required and must be a string",
+        });
+      });
+
+      it("should reject invalid capability", () => {
+        const data = { ...validJobData, capability: "InvalidCapability" };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "capability",
+          message: "Capability must be one of: Data, Workday, Engineering",
+        });
+      });
+
+      it("should accept valid capabilities", () => {
+        for (const capability of Object.values(Capability)) {
+          const data = { ...validJobData, capability };
+          const result = validateJobRoleData(data);
+          const capabilityErrors = result.errors.filter(
+            (e) => e.field === "capability"
+          );
+          expect(capabilityErrors).toHaveLength(0);
+        }
+      });
+    });
+
+    describe("band validation", () => {
+      it("should require band", () => {
+        const data = { ...validJobData, band: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "band",
+          message: "Band is required and must be a string",
+        });
+      });
+
+      it("should reject invalid band", () => {
+        const data = { ...validJobData, band: "E10" };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "band",
+          message: "Band must be one of: E1, E2, E3, E4, E5",
+        });
+      });
+
+      it("should accept valid bands", () => {
+        for (const band of Object.values(Band)) {
+          const data = { ...validJobData, band };
+          const result = validateJobRoleData(data);
+          const bandErrors = result.errors.filter((e) => e.field === "band");
+          expect(bandErrors).toHaveLength(0);
+        }
+      });
+    });
+
+    describe("closingDate validation", () => {
+      it("should require closing date", () => {
+        const data = { ...validJobData, closingDate: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "closingDate",
+          message: "Closing date is required",
+        });
+      });
+
+      it("should reject invalid date", () => {
+        const data = { ...validJobData, closingDate: "invalid-date" };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "closingDate",
+          message: "Closing date must be a valid date",
+        });
+      });
+
+      it("should reject past dates", () => {
+        const data = { ...validJobData, closingDate: new Date("2020-01-01") };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "closingDate",
+          message: "Closing date must be in the future",
+        });
+      });
+    });
+
+    describe("numberOfOpenPositions validation", () => {
+      it("should require numberOfOpenPositions", () => {
+        const data = { ...validJobData, numberOfOpenPositions: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "numberOfOpenPositions",
+          message: "Number of open positions is required",
+        });
+      });
+
+      it("should reject non-integer values", () => {
+        const data = { ...validJobData, numberOfOpenPositions: 1.5 };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "numberOfOpenPositions",
+          message: "Number of open positions must be a positive integer",
+        });
+      });
+
+      it("should reject zero or negative values", () => {
+        const data = { ...validJobData, numberOfOpenPositions: 0 };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "numberOfOpenPositions",
+          message: "Number of open positions must be a positive integer",
+        });
+      });
+    });
+
+    describe("status validation", () => {
+      it("should require status", () => {
+        const data = { ...validJobData, status: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "status",
+          message: "Status is required and must be a string",
+        });
+      });
+
+      it("should reject invalid status", () => {
+        const data = { ...validJobData, status: "InvalidStatus" };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "status",
+          message: "Status must be one of: Open, Closed",
+        });
+      });
+    });
+
+    describe("description validation", () => {
+      it("should require description", () => {
+        const data = { ...validJobData, description: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "description",
+          message: "Description is required and must be a non-empty string",
+        });
+      });
+
+      it("should reject empty description", () => {
+        const data = { ...validJobData, description: "   " };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "description",
+          message: "Description is required and must be a non-empty string",
+        });
+      });
+    });
+
+    describe("responsibilities validation", () => {
+      it("should require responsibilities", () => {
+        const data = { ...validJobData, responsibilities: undefined };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "responsibilities",
+          message: "Responsibilities are required",
+        });
+      });
+
+      it("should reject non-array responsibilities", () => {
+        const data = { ...validJobData, responsibilities: "not an array" };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "responsibilities",
+          message: "Responsibilities must be an array",
+        });
+      });
+
+      it("should reject empty responsibilities array", () => {
+        const data = { ...validJobData, responsibilities: [] };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "responsibilities",
+          message: "At least one responsibility is required",
+        });
+      });
+
+      it("should reject non-string responsibilities", () => {
+        const data = { ...validJobData, responsibilities: ["valid", 123, ""] };
+        const result = validateJobRoleData(data);
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toContainEqual({
+          field: "responsibilities[1]",
+          message: "Each responsibility must be a non-empty string",
+        });
+        expect(result.errors).toContainEqual({
+          field: "responsibilities[2]",
+          message: "Each responsibility must be a non-empty string",
+        });
+      });
+    });
+  });
+
+  describe("sanitizeJobRoleData", () => {
+    it("should sanitize and convert valid data", () => {
+      const input = {
+        name: "  Software Engineer  ",
+        location: "  London  ",
+        capability: Capability.Engineering,
+        band: Band.E3,
+        closingDate: "2025-12-31",
+        numberOfOpenPositions: "2",
+        status: JobStatus.Open,
+        description: "  A great role  ",
+        responsibilities: ["  Task 1  ", "  Task 2  ", ""],
+      };
+
+      const result = sanitizeJobRoleData(input);
+
+      expect(result).toEqual({
+        name: "Software Engineer",
+        location: "London",
+        capability: Capability.Engineering,
+        band: Band.E3,
+        closingDate: new Date("2025-12-31"),
+        numberOfOpenPositions: 2,
+        status: JobStatus.Open,
+        description: "A great role",
+        responsibilities: ["Task 1", "Task 2"],
+      });
+    });
+
+    it("should handle missing or invalid data gracefully", () => {
+      const input = {
+        name: undefined,
+        location: null,
+        capability: Capability.Data,
+        band: Band.E1,
+        closingDate: "2025-01-01",
+        numberOfOpenPositions: "invalid",
+        status: JobStatus.Open,
+        description: undefined,
+        responsibilities: null,
+      };
+
+      const result = sanitizeJobRoleData(input);
+
+      expect(result).toEqual({
+        name: "",
+        location: "",
+        capability: Capability.Data,
+        band: Band.E1,
+        closingDate: new Date("2025-01-01"),
+        numberOfOpenPositions: 1,
+        status: JobStatus.Open,
+        description: "",
+        responsibilities: [],
+      });
+    });
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,177 @@
+import { Band, Capability, JobStatus } from "../models/job-role.js";
+import type { JobRoleCreateData } from "../services/interfaces.js";
+
+export interface ValidationError {
+    field: string;
+    message: string;
+}
+
+export interface ValidationResult {
+    isValid: boolean;
+    errors: ValidationError[];
+}
+
+//Claude insists that unknown is appropriate here as the user entered data could be anything
+export const validateJobRoleData = (data: unknown): ValidationResult => {
+    const errors: ValidationError[] = [];
+
+    // Type guard to safely access properties
+    const dataObj = data as Record<string, unknown>;
+    if (
+        !dataObj.name ||
+        typeof dataObj.name !== "string" ||
+        dataObj.name.trim() === ""
+    ) {
+        errors.push({
+            field: "name",
+            message: "Name is required and must be a non-empty string",
+        });
+    }
+
+    if (
+        !dataObj.location ||
+        typeof dataObj.location !== "string" ||
+        dataObj.location.trim() === ""
+    ) {
+        errors.push({
+            field: "location",
+            message: "Location is required and must be a non-empty string",
+        });
+    }
+
+    if (!dataObj.capability || typeof dataObj.capability !== "string") {
+        errors.push({
+            field: "capability",
+            message: "Capability is required and must be a string",
+        });
+    } else if (
+        !Object.values(Capability).includes(dataObj.capability as Capability)
+    ) {
+        errors.push({
+            field: "capability",
+            message: `Capability must be one of: ${Object.values(Capability).join(", ")}`,
+        });
+    }
+
+    if (!dataObj.band || typeof dataObj.band !== "string") {
+        errors.push({
+            field: "band",
+            message: "Band is required and must be a string",
+        });
+    } else if (!Object.values(Band).includes(dataObj.band as Band)) {
+        errors.push({
+            field: "band",
+            message: `Band must be one of: ${Object.values(Band).join(", ")}`,
+        });
+    }
+
+    if (!dataObj.closingDate) {
+        errors.push({ field: "closingDate", message: "Closing date is required" });
+    } else {
+        const closingDate = new Date(dataObj.closingDate as string);
+        if (Number.isNaN(closingDate.getTime())) {
+            errors.push({
+                field: "closingDate",
+                message: "Closing date must be a valid date",
+            });
+        } else if (closingDate <= new Date()) {
+            errors.push({
+                field: "closingDate",
+                message: "Closing date must be in the future",
+            });
+        }
+    }
+
+    if (
+        dataObj.numberOfOpenPositions === undefined ||
+        dataObj.numberOfOpenPositions === null
+    ) {
+        errors.push({
+            field: "numberOfOpenPositions",
+            message: "Number of open positions is required",
+        });
+    } else if (
+        !Number.isInteger(dataObj.numberOfOpenPositions) ||
+        (typeof dataObj.numberOfOpenPositions === "number" &&
+            dataObj.numberOfOpenPositions < 1)
+    ) {
+        errors.push({
+            field: "numberOfOpenPositions",
+            message: "Number of open positions must be a positive integer",
+        });
+    }
+
+    if (!dataObj.status || typeof dataObj.status !== "string") {
+        errors.push({
+            field: "status",
+            message: "Status is required and must be a string",
+        });
+    } else if (!Object.values(JobStatus).includes(dataObj.status as JobStatus)) {
+        errors.push({
+            field: "status",
+            message: `Status must be one of: ${Object.values(JobStatus).join(", ")}`,
+        });
+    }
+
+    if (
+        !dataObj.description ||
+        typeof dataObj.description !== "string" ||
+        dataObj.description.trim() === ""
+    ) {
+        errors.push({
+            field: "description",
+            message: "Description is required and must be a non-empty string",
+        });
+    }
+
+    if (!dataObj.responsibilities) {
+        errors.push({
+            field: "responsibilities",
+            message: "Responsibilities are required",
+        });
+    } else if (!Array.isArray(dataObj.responsibilities)) {
+        errors.push({
+            field: "responsibilities",
+            message: "Responsibilities must be an array",
+        });
+    } else if (dataObj.responsibilities.length === 0) {
+        errors.push({
+            field: "responsibilities",
+            message: "At least one responsibility is required",
+        });
+    } else {
+        dataObj.responsibilities.forEach((resp: unknown, index: number) => {
+            if (typeof resp !== "string" || resp.trim() === "") {
+                errors.push({
+                    field: `responsibilities[${index}]`,
+                    message: "Each responsibility must be a non-empty string",
+                });
+            }
+        });
+    }
+
+    return {
+        isValid: errors.length === 0,
+        errors,
+    };
+};
+//Claude insists that unknown is appropriate here as the user entered data could be anything
+export const sanitizeJobRoleData = (data: unknown): JobRoleCreateData => {
+    const dataObj = data as Record<string, unknown>;
+
+    return {
+        name: dataObj.name?.toString().trim() || "",
+        location: dataObj.location?.toString().trim() || "",
+        capability: dataObj.capability as Capability,
+        band: dataObj.band as Band,
+        closingDate: new Date((dataObj.closingDate as string) || ""),
+        numberOfOpenPositions: Number(dataObj.numberOfOpenPositions) || 1,
+        status: dataObj.status as JobStatus,
+        description: dataObj.description?.toString().trim() || "",
+        responsibilities: Array.isArray(dataObj.responsibilities)
+            ? dataObj.responsibilities
+                .map((resp) => resp?.toString().trim())
+                .filter((item): item is string => Boolean(item))
+            : [],
+    };
+};


### PR DESCRIPTION
- Add ID field to JobRole model for proper CRUD operations
- Extend JobRoleService interface with addJob method
- Implement addJob in JobRoleMemoryService with auto ID generation
- Add comprehensive validation utilities for job role data
- Create POST /api/jobs endpoint with validation and error handling
- Add comprehensive test suite (51 tests passing)
- Use dependency injection pattern for future API integration